### PR TITLE
[DNM] mocking up a github provider

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -1,5 +1,5 @@
 {
-  "trimet": {
-    "key": "8A0EBB788E8205888807BAC97"
+  "github": {
+    "key": "foobaz"
   }
 }

--- a/index.js
+++ b/index.js
@@ -8,9 +8,9 @@
 
 const provider = {
   type: 'provider',
-  name: 'sample',
-  hosts: false,
-  disableIdParam: true,
+  name: 'github',
+  hosts: true,
+  disableIdParam: false,
   Controller: require('./controller'),
   Model: require('./model'),
   routes: require('./routes'),

--- a/model.js
+++ b/model.js
@@ -8,16 +8,30 @@
 const request = require('request').defaults({gzip: true, json: true})
 const config = require('config')
 
+const base = 'https://raw.github.com'
+const hardboiled = 'https://raw.github.com/chelm/grunt-geo/master/samples/Leaflet.geojson'
+
 function Model (koop) {}
 
-// This is the only public function you need to implement
 Model.prototype.getData = function (req, callback) {
-  // Call the remote API with our developer key
-  const key = config.trimet.key
-  request(`https://developer.trimet.org/ws/v2/vehicles/onRouteOnly/false/appid/${key}`, (err, res, body) => {
+
+  const key = config.github.key || process.env.KOOP_GITHUB_TOKEN || null
+
+  // not sure if using hosts like this is kosher
+  const user = req.params.host
+  const repo = req.params.id
+
+  const full = base + '/' + user + '/' + repo + '/' + 'master/samples/Leaflet.geojson'
+
+  // how to expose more url parameters?  ie: folder+file, branch
+  // console.log(req.params)
+
+  // not sending github token in request (yet)
+  request(hardboiled, (err, res, body) => {
     if (err) return callback(err)
     // translate the response into geojson
     const geojson = translate(body)
+
     // Cache data for 10 seconds at a time by setting the ttl or "Time to Live"
     geojson.ttl = 10
     // hand off the data to Koop
@@ -26,67 +40,8 @@ Model.prototype.getData = function (req, callback) {
 }
 
 function translate (input) {
-  return {
-    type: 'FeatureCollection',
-    features: input.resultSet.vehicle.map(formatFeature)
-  }
-}
-
-function formatFeature (vehicle) {
-  // Most of what we need to do here is extract the longitude and latitude
-  const feature = {
-    type: 'Feature',
-    properties: vehicle,
-    geometry: {
-      type: 'Point',
-      coordinates: [vehicle.longitude, vehicle.latitude]
-    }
-  }
-  // But we also want to translate a few of the date fields so they are easier to use downstream
-  const dateFields = ['expires', 'serviceDate', 'time']
-  dateFields.forEach(field => {
-    feature.properties[field] = new Date(feature.properties[field]).toISOString()
-  })
-  return feature
+  // nothing to convert, we're already asking GitHub for GeoJSON
+  return input
 }
 
 module.exports = Model
-
-/* Example raw API response
-{
-  "resultSet": {
-  "queryTime": 1488465776220,
-  "vehicle": [
-    {
-      "expires": 1488466246000,
-      "signMessage": "Red Line to Beaverton",
-      "serviceDate": 1488441600000,
-      "loadPercentage": null,
-      "latitude": 45.5873117,
-      "nextStopSeq": 1,
-      "source": "tab",
-      "type": "rail",
-      "blockID": 9045,
-      "signMessageLong": "MAX  Red Line to City Center & Beaverton",
-      "lastLocID": 10579,
-      "nextLocID": 10579,
-      "locationInScheduleDay": 24150,
-      "newTrip": false,
-      "longitude": -122.5927705,
-      "direction": 1,
-      "inCongestion": null,
-      "routeNumber": 90,
-      "bearing": 145,
-      "garage": "ELMO",
-      "tripID": "7144393",
-      "delay": -16,
-      "extraBlockID": null,
-      "messageCode": 929,
-      "lastStopSeq": 26,
-      "vehicleID": 102,
-      "time": 1488465767051,
-      "offRoute": false
-    }
-  ]
-}
-*/

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "koop-trimet",
-  "version": "1.0.8",
-  "description": "A Trimet provider for koop",
+  "name": "koop-provider-github",
+  "version": "1.0.0",
+  "description": "A GitHub provider for koop",
   "main": "index.js",
   "directories": {
     "test": "test"

--- a/server.js
+++ b/server.js
@@ -18,7 +18,7 @@ koop.server.listen(port)
 
 const message = `
 
-Koop Sample Provider listening on ${port}
+Koop Github Provider listening on ${port}
 For more docs visit: https://koopjs.github.io/docs/specs/provider/
 To find providers visit: https://www.npmjs.com/search?q=koop+provider
 


### PR DESCRIPTION
well, it couldn't be much more straightforward to implement a new provider when all its doing is fetching `.geojson`, but in taking my first crack at rewriting `koop-github` this afternoon i came up with a few questions.

1. for the trimet sample, what is the syntax to just ask for raw GeoJSON instead of an Esri feature service?

2. the `host` and `id` params make it convenient to map a dynamic request, but how should i go about passing through additional parameters (like the `folder+file` where the geojson actually lives). am i correct in assuming this happens via a custom route?