### PR TITLE
DNM: Example of how to register a provider with secured services.

### DIFF
--- a/server.js
+++ b/server.js
@@ -3,7 +3,7 @@ process.on('SIGINT', () => process.exit(0))
 process.on('SIGTERM', () => process.exit(0))
 
 // Initialize Koop
-const Koop = require('./koop-core/src')
+const Koop = require('koop')
 const koop = new Koop()
 
 // Install Craigslist Provider

--- a/server.js
+++ b/server.js
@@ -8,7 +8,7 @@ const koop = new Koop()
 
 // Install Craigslist Provider
 const koopCraigslist = require('./koop-provider-craigslist')
-//Add middleware to provider routes to prevent unauntheticated access
+// Add middleware to provider routes to prevent unauntheticated access
 koop.server.use(`/${koopCraigslist.name}`, koopCraigslist.middleware.tokenValidator(koopCraigslist.name))
 
 koop.register(koopCraigslist)

--- a/server.js
+++ b/server.js
@@ -3,12 +3,15 @@ process.on('SIGINT', () => process.exit(0))
 process.on('SIGTERM', () => process.exit(0))
 
 // Initialize Koop
-const Koop = require('koop')
+const Koop = require('./koop-core/src')
 const koop = new Koop()
 
-// Install the Sample Provider
-const provider = require('./')
-koop.register(provider)
+// Install Craigslist Provider
+const koopCraigslist = require('./koop-provider-craigslist')
+//Add middleware to provider routes to prevent unauntheticated access
+koop.server.use(`/${koopCraigslist.name}`, koopCraigslist.middleware.tokenValidator(koopCraigslist.name))
+
+koop.register(koopCraigslist)
 
 if (process.env.DEPLOY === 'export') {
   module.exports = koop.server


### PR DESCRIPTION
Showing how middleware for checking a access-token can be added post- provider registration.  Alternatives to this could include moving this to the koop-core provider registration, or encapsulating all the auth code as its own module that can be added to multiple providers.