### PR TITLE
Add process.env.PORT as an alternative to config.port and 8080 port. …

### DIFF
--- a/server.js
+++ b/server.js
@@ -16,7 +16,7 @@ if (process.env.DEPLOY === 'export') {
   // Start listening for HTTP traffic
   const config = require('config')
   // Set port for configuration or fall back to default
-  const port = config.port || 8080
+  const port = process.env.PORT || config.port || 8080
   koop.server.listen(port)
 
   const message = `


### PR DESCRIPTION
To make the app ready for Heroku platform.
This will make it easier to deploy the individual koop provider as a stand alone application in the platform.
