### PR TITLE
Fix broken links to Koop Provider docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This is a sample that demonstrates how to build a Koop Provider. You can clone t
 
 The data source in this example is the [TriMet Bus API](https://developer.trimet.org). You can see this provider in action [here](http://dcdev.maps.arcgis.com/home/item.html?id=2603e7e3f10742f78093edf8ea2adfd8#visualize).
 
-Full documentation is provided [here](https://koopjs.github.io/docs/specs/provider/).
+Full documentation is provided [here](https://koopjs.github.io/docs/usage/provider).
 
 ## Getting started
 

--- a/controller.js
+++ b/controller.js
@@ -4,7 +4,7 @@
   This file is not required unless additional routes specified in routes.js
   If so, corresponding functions must be written to match those routes.
 
-  Documentation: http://koopjs.github.io/docs/specs/provider/
+  Documentation: http://koopjs.github.io/docs/usage/provider
 */
 
 function Controller (model) {

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 
   This file is required. It's role is to specify configuration settings.
 
-  Documentation: http://koopjs.github.io/docs/specs/provider/
+  Documentation: http://koopjs.github.io/docs/usage/provider
 */
 
 // Define the provider path

--- a/model.js
+++ b/model.js
@@ -3,7 +3,7 @@
 
   This file is required. It must export a class with at least one public function called `getData`
 
-  Documentation: http://koopjs.github.io/docs/specs/provider/
+  Documentation: http://koopjs.github.io/docs/usage/provider
 */
 const request = require('request').defaults({gzip: true, json: true})
 const config = require('config')

--- a/routes.js
+++ b/routes.js
@@ -2,6 +2,6 @@
   routes.js
 
   This file is an optional place to specify additional routes to be handled by this provider's controller
-  Documentation: http://koopjs.github.io/docs/specs/provider/
+  Documentation: http://koopjs.github.io/docs/usage/provider
 */
 module.exports = []

--- a/server.js
+++ b/server.js
@@ -22,7 +22,7 @@ if (process.env.DEPLOY === 'export') {
   const message = `
 
   Koop Sample Provider listening on ${port}
-  For more docs visit: https://koopjs.github.io/docs/specs/provider/
+  For more docs visit: https://koopjs.github.io/docs/usage/provider
   To find providers visit: https://www.npmjs.com/search?q=koop+provider
 
   Try it out in your browser: http://localhost:${port}/sample/FeatureServer/0/query


### PR DESCRIPTION
And yes, the new URL only works without the trailing slash. :/