### PR TITLE
fix: lambda-create typo and correct --set-env args

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "start": "node server.js",
     "test": "standard && tape test/*.js | tap-spec",
-    "lamda-create": "claudia create --name koop-provider-geojson --handler lambda.handler --deploy-proxy-api --region us-east-1 --set-env KOOP_PORT=80 --set-env DEPLOY=export",
+    "lambda-create": "claudia create --name koop-provider-geojson --handler lambda.handler --deploy-proxy-api --region us-east-1 --set-env KOOP_PORT=80,DEPLOY=export",
     "lambda-update": "claudia update"
   },
   "dependencies": {


### PR DESCRIPTION
Fixed typo in script name and change --set-env args to accepted comma-separated list. https://github.com/claudiajs/claudia/blob/master/docs/create.md